### PR TITLE
Improve strnstr fallback for non-Linux GNU libc platforms

### DIFF
--- a/src/orcania.c
+++ b/src/orcania.c
@@ -245,7 +245,7 @@ char * o_strrchr(const char * haystack, int c) {
   }
 }
 
-#ifdef __linux__ 
+#if defined(__linux__) || defined(__GLIBC__)
 char *strnstr(const char *haystack, const char *needle, size_t len) {
   int i;
   size_t needle_len;

--- a/src/orcania.c
+++ b/src/orcania.c
@@ -246,7 +246,7 @@ char * o_strrchr(const char * haystack, int c) {
 }
 
 #if defined(__linux__) || defined(__GLIBC__)
-char *strnstr(const char *haystack, const char *needle, size_t len) {
+static char *strnstr(const char *haystack, const char *needle, size_t len) {
   int i;
   size_t needle_len;
 


### PR DESCRIPTION
This fixes orcania on non-Linux platforms based on GNU libc, such as GNU/kFreeBSD and GNU/Hurd, avoid leaking the fallback function too.