### PR TITLE
run ldconfig in install dir

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,7 @@ install: all $(PKGCONFIG_FILE)
 	install -m644 $(PKGCONFIG_FILE) $(DESTDIR)/lib/pkgconfig
 	install -m644 ../include/orcania.h $(DESTDIR)/include
 	install -m644 $(CONFIG_FILE) $(DESTDIR)/include
-	-ldconfig
+	-ldconfig $(DESTDIR)/lib
 
 static-install: static
 	install liborcania.a $(DESTDIR)/lib


### PR DESCRIPTION
if the distribution doesn't include, let's say, the default /usr/local/lib in ld.so.conf, `make install` will only install the `$(OUTPUT).$(VERSION)` file and consequent tools using orcania will fail to link.

with this patch, ldconfig runs in `$(DESTDIR)` explicitly and installs correctly.

bug found by @karl34 on centos 7