### PR TITLE
Changes in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,18 @@ jobs:
     - env: LABEL=cppcheck
       script:
         - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 .
+# For PPPC64Le
+    - env: LABEL=linux-gcc
+      arch: ppc64le
+      compiler: gcc
+    - env: LABEL=lnux-clang
+      arch: ppc64le
+      compiler: clang
+    - env: LABEL=cppcheck
+      arch: ppc64le
+      script:
+        - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 .
+
 script:
   - pushd test
   - make test


### PR DESCRIPTION
Add support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.org/github/nageshlop/orcania/builds/745364035