### PR TITLE
Enable WITH_STRSTR by default if the system doesn't provide a strnstr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 # Copyright 2018 Silvio Clecio <silvioprog@gmail.com>
 # Copyright 2018-2022 Nicolas Mora <mail@babelouest.org>
+# Copyright 2022 ChihHao Su <nikob@live.cn>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License
@@ -81,6 +82,9 @@ if (_GNU_SOURCE)
     add_definitions(-D_GNU_SOURCE)
 endif ()
 
+
+
+
 # directories and source
 
 set(INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -95,12 +99,20 @@ set(LIB_SRC
         ${SRC_DIR}/memory.c
         ${SRC_DIR}/orcania.c)
 
-option(WITH_STRSTR "Use inline implementation of strstr" OFF)
+# Enable option WITH_STRSTR by default if the system doesn't provide a strnstr.
+check_symbol_exists(strnstr "string.h" HAVE_STRNSTR)
+if (NOT WITH_STRSTR)
+	option(WITH_STRSTR "Use inline implementation of strstr" ON)
+else ()
+	option(WITH_STRSTR "Use inline implementation of strstr" OFF)
+endif ()
+
 if (WITH_STRSTR)
     set(O_STRSTR ON)
 else ()
     set(O_STRSTR OFF)
 endif ()
+
 
 set(PKGCONF_REQ "")
 set(PKGCONF_REQ_PRIVATE "")
@@ -116,7 +128,7 @@ option(BUILD_STATIC "Build static library." OFF)
 
 if (BUILD_STATIC)
     add_library(orcania_static STATIC ${LIB_SRC})
-    target_compile_definitions(orcania_static PUBLIC -DO_STATIC_LIBRARY)
+    target_compile_definitions(orcania_static PUBLIC -DO_STATIC_LIBRARY ${DEFS})
     set_target_properties(orcania_static PROPERTIES
             OUTPUT_NAME orcania)
 endif ()
@@ -124,6 +136,7 @@ endif ()
 # shared library
 
 add_library(orcania SHARED ${LIB_SRC})
+target_compile_definitions(orcania PUBLIC ${DEFS})
 if (NOT MSVC)
     set_target_properties(orcania PROPERTIES
             COMPILE_OPTIONS -Wextra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,9 +99,9 @@ set(LIB_SRC
 # Enable option WITH_STRSTR by default if the system doesn't provide a strnstr.
 check_symbol_exists(strnstr "string.h" HAVE_STRNSTR)
 if (NOT WITH_STRSTR)
-	option(WITH_STRSTR "Use inline implementation of strstr" ON)
+    option(WITH_STRSTR "Use inline implementation of strstr" ON)
 else ()
-	option(WITH_STRSTR "Use inline implementation of strstr" OFF)
+    option(WITH_STRSTR "Use inline implementation of strstr" OFF)
 endif ()
 
 if (WITH_STRSTR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ option(BUILD_STATIC "Build static library." OFF)
 
 if (BUILD_STATIC)
     add_library(orcania_static STATIC ${LIB_SRC})
-    target_compile_definitions(orcania_static PUBLIC -DO_STATIC_LIBRARY ${DEFS})
+    target_compile_definitions(orcania_static PUBLIC -DO_STATIC_LIBRARY)
     set_target_properties(orcania_static PROPERTIES
             OUTPUT_NAME orcania)
 endif ()
@@ -136,7 +136,6 @@ endif ()
 # shared library
 
 add_library(orcania SHARED ${LIB_SRC})
-target_compile_definitions(orcania PUBLIC ${DEFS})
 if (NOT MSVC)
     set_target_properties(orcania PROPERTIES
             COMPILE_OPTIONS -Wextra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,6 @@ if (_GNU_SOURCE)
     add_definitions(-D_GNU_SOURCE)
 endif ()
 
-
-
-
 # directories and source
 
 set(INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
I'm using OpenBSD. When I compile orcania, I got:
```
/home/niko/compile_from_src/orcania/src/orcania.c:401:12: error: implicit declaration of function 'strnstr' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    return strnstr(haystack, needle, len);
           ^
/home/niko/compile_from_src/orcania/src/orcania.c:401:12: note: did you mean 'strstr'?
/usr/include/string.h:89:7: note: 'strstr' declared here
char    *strstr(const char *, const char *);
```
I know every thing will be ok if I enable `WITH_STRSTR` option. But you cannot compile it without checking the source code and figuring out what's happend. It's not user-friendly.

I think it's better to enable that by default, if the system doesn't provide a `strnstr`.