### PR TITLE
Fixes to get orcania building with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,13 @@ set(PROJECT_BUGREPORT_PATH "https://github.com/babelouest/orcania/issues")
 set(LIBRARY_VERSION_MAJOR "2")
 set(LIBRARY_VERSION_MINOR "3")
 set(LIBRARY_VERSION_PATCH "1")
-set(LIBS)
 
 set(PROJECT_VERSION "${LIBRARY_VERSION_MAJOR}.${LIBRARY_VERSION_MINOR}.${LIBRARY_VERSION_PATCH}")
 set(PROJECT_VERSION_MAJOR ${LIBRARY_VERSION_MAJOR})
 set(PROJECT_VERSION_MINOR ${LIBRARY_VERSION_MINOR})
 set(PROJECT_VERSION_PATCH ${LIBRARY_VERSION_PATCH})
+
+set(ORCANIA_LIBS)
 
 if (${LIBRARY_VERSION_MAJOR} VERSION_LESS 10)
     set (LIBRARY_VERSION_MAJOR_PAD "0${LIBRARY_VERSION_MAJOR}")
@@ -65,6 +66,7 @@ list(APPEND CMAKE_MODULE_PATH "${O_CMAKE_MODULE_PATH}")
 
 include(GNUInstallDirs)
 include(CheckSymbolExists)
+include(CMakePackageConfigHelpers)
 
 # check if _GNU_SOURCE is available
 
@@ -87,8 +89,6 @@ set(INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(BASE64URL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tools/base64url)
 
-include_directories(${INC_DIR})
-
 set(LIB_SRC
         ${INC_DIR}/orcania.h # allow many IDEs to find and edit it
         ${SRC_DIR}/base64.c
@@ -108,9 +108,6 @@ set(PKGCONF_REQ_PRIVATE "")
 # build orcania-cfg.h file
 configure_file(${INC_DIR}/orcania-cfg.h.in ${PROJECT_BINARY_DIR}/orcania-cfg.h)
 set (CMAKE_EXTRA_INCLUDE_FILES ${PROJECT_BINARY_DIR})
-include_directories(${PROJECT_BINARY_DIR})
-
-# static library
 
 option(BUILD_SHARED "Build shared library." ON)
 option(BUILD_STATIC "Build static library." OFF)
@@ -119,19 +116,27 @@ if (NOT BUILD_STATIC AND NOT BUILD_SHARED)
     message(FATAL_ERROR "BUILD_SHARED and BUILD_STATIC cannot be both disabled")
 endif ()
 
+# static library
+
 if (BUILD_STATIC)
     add_library(orcania_static STATIC ${LIB_SRC})
+    add_library(Orcania::Orcania-static ALIAS orcania_static)
+    target_include_directories(orcania_static
+            PUBLIC "$<BUILD_INTERFACE:${INC_DIR}>"
+            PUBLIC "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
+            PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+    target_link_libraries(orcania_static PRIVATE ${ORCANIA_LIBS})
+    target_compile_definitions(orcania_static PUBLIC O_STATIC_LIBRARY)
     set_target_properties(orcania_static PROPERTIES
-            PUBLIC_HEADER "${INC_DIR}/orcania.h;${PROJECT_BINARY_DIR}/orcania-cfg.h")
-    target_compile_definitions(orcania_static PUBLIC -DO_STATIC_LIBRARY)
-    set_target_properties(orcania_static PROPERTIES
-            OUTPUT_NAME orcania)
+            PUBLIC_HEADER "${INC_DIR}/orcania.h;${PROJECT_BINARY_DIR}/orcania-cfg.h"
+            OUTPUT_NAME orcania
+            EXPORT_NAME Orcania-static)
     if (MSVC)
         set_target_properties(orcania_static PROPERTIES
                 OUTPUT_NAME orcania-static)
-    else ()
-        set_target_properties(orcania_static PROPERTIES
-            COMPILE_OPTIONS "-Wextra;-Wconversion")
+    endif ()
+    if (NOT MSVC)
+        target_compile_options(orcania_static PRIVATE -Wextra -Wconversion)
     endif ()
     set(orcania_lib orcania_static)
 endif ()
@@ -140,20 +145,25 @@ endif ()
 
 if (BUILD_SHARED)
     add_library(orcania SHARED ${LIB_SRC})
+    add_library(Orcania::Orcania ALIAS orcania)
+    target_include_directories(orcania
+            PUBLIC "$<BUILD_INTERFACE:${INC_DIR}>"
+            PUBLIC "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
+            PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+    target_link_libraries(orcania PRIVATE ${ORCANIA_LIBS})
     set_target_properties(orcania PROPERTIES
             PUBLIC_HEADER "${INC_DIR}/orcania.h;${PROJECT_BINARY_DIR}/orcania-cfg.h"
             VERSION "${LIBRARY_VERSION}"
             SOVERSION "${LIBRARY_SOVERSION}"
-            WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-    if (NOT MSVC)
-        set_target_properties(orcania PROPERTIES
-            COMPILE_OPTIONS "-Wextra;-Wconversion")
-    endif ()
+            WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+            EXPORT_NAME Orcania)
     if (WIN32)
         set_target_properties(orcania PROPERTIES
-                    SUFFIX "-${LIBRARY_VERSION_MAJOR}.dll")
+                SUFFIX "-${LIBRARY_VERSION_MAJOR}.dll")
     endif ()
-    target_link_libraries(orcania ${LIBS})
+    if (NOT MSVC)
+        target_compile_options(orcania PRIVATE -Wextra -Wconversion)
+    endif ()
     set(orcania_lib orcania)
 endif ()
 
@@ -187,10 +197,9 @@ if (BUILD_BASE64URL)
     add_executable(base64url ${BASE64URL_DIR}/base64url.c ${INC_DIR}/orcania.h ${PROJECT_BINARY_DIR}/orcania-cfg.h)
     set_target_properties(base64url PROPERTIES SKIP_BUILD_RPATH TRUE)
     if (NOT MSVC)
-        set_target_properties(base64url COMPILE_OPTIONS "-Wextra;-Wconversion")
+        target_compile_options(base64url PRIVATE -Wextra -Wconversion)
     endif ()
-    add_dependencies(base64url ${orcania_lib})
-    target_link_libraries(base64url ${orcania_lib} ${LIBS})
+    target_link_libraries(base64url PRIVATE ${orcania_lib})
     install(TARGETS base64url RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES ${BASE64URL_DIR}/base64url.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT runtime)
 endif ()
@@ -200,11 +209,9 @@ endif ()
 option(BUILD_ORCANIA_TESTING "Build the testing tree." OFF) # because we do not use include(CTest)
 
 if (BUILD_ORCANIA_TESTING)
-    include(FindCheck)
     find_package(Check)
     if (CHECK_FOUND)
         if (NOT WIN32 AND NOT APPLE)
-            include(FindSubunit)
             find_package(Subunit REQUIRED)
         endif ()
 
@@ -213,16 +220,16 @@ if (BUILD_ORCANIA_TESTING)
         set(CMAKE_CTEST_COMMAND ctest -V)
 
         set(TST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test)
-        set(LIBS orcania ${LIBS} ${CHECK_LIBRARIES})
+        set(TEST_LIBS ${orcania_lib} Check::Check)
         if (NOT WIN32)
             find_package(Threads REQUIRED)
-            set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT} m)
+            list(APPEND TEST_LIBS Threads::Threads m)
         endif ()
-        if (NOT APPLE)
-            set(LIBS ${LIBS} rt)
+        if (NOT APPLE AND NOT MSVC)
+            list(APPEND TEST_LIBS rt)
         endif ()
         if (NOT WIN32 AND NOT APPLE)
-            set(LIBS ${LIBS} ${SUBUNIT_LIBRARIES} rt)
+            list(APPEND TEST_LIBS Subunit::Subunit rt)
         endif ()
 
         set(TESTS
@@ -239,7 +246,7 @@ if (BUILD_ORCANIA_TESTING)
         foreach (t ${TESTS})
             add_executable(${t} EXCLUDE_FROM_ALL ${TST_DIR}/${t}.c)
             target_include_directories(${t} PUBLIC ${TST_DIR})
-            target_link_libraries(${t} PUBLIC ${LIBS})
+            target_link_libraries(${t} PRIVATE ${TEST_LIBS})
             add_test(NAME ${t}
                     WORKING_DIRECTORY ${TST_DIR}
                     COMMAND ${t})
@@ -277,17 +284,37 @@ if (BUILD_STATIC)
 endif ()
 
 if (INSTALL_HEADER)
-    install(TARGETS ${TARGETS}
+    install(TARGETS ${TARGETS} EXPORT OrcaniaExports
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 else ()
-    install(TARGETS ${TARGETS}
+    install(TARGETS ${TARGETS} EXPORT OrcaniaExports
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()
+
+set(ORCANIA_INSTALL_CMAKEDIR_DEFAULT "${CMAKE_INSTALL_LIBDIR}/cmake/Orcania")
+if (WIN32 AND NOT MINGW)
+    set(ORCANIA_INSTALL_CMAKEDIR_DEFAULT "cmake")
+endif ()
+set(ORCANIA_INSTALL_CMAKEDIR ${ORCANIA_INSTALL_CMAKEDIR_DEFAULT} CACHE STRING "Location where to install the cmake config files")
+
+install(EXPORT OrcaniaExports DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}"
+        NAMESPACE "Orcania::"
+        FILE "OrcaniaTargets.cmake")
+
+configure_package_config_file(cmake-modules/OrcaniaConfig.cmake.in OrcaniaConfig.cmake
+        INSTALL_DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}")
+write_basic_package_version_file(OrcaniaConfigVersion.cmake
+        COMPATIBILITY AnyNewerVersion)
+
+install(FILES
+            "${PROJECT_BINARY_DIR}/OrcaniaConfig.cmake"
+            "${PROJECT_BINARY_DIR}/OrcaniaConfigVersion.cmake"
+        DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}")
 
 # uninstall target
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,29 +112,50 @@ include_directories(${PROJECT_BINARY_DIR})
 
 # static library
 
+option(BUILD_SHARED "Build shared library." ON)
 option(BUILD_STATIC "Build static library." OFF)
+
+if (NOT BUILD_STATIC AND NOT BUILD_SHARED)
+    message(FATAL_ERROR "BUILD_SHARED and BUILD_STATIC cannot be both disabled")
+endif ()
 
 if (BUILD_STATIC)
     add_library(orcania_static STATIC ${LIB_SRC})
+    set_target_properties(orcania_static PROPERTIES
+            PUBLIC_HEADER "${INC_DIR}/orcania.h;${PROJECT_BINARY_DIR}/orcania-cfg.h")
     target_compile_definitions(orcania_static PUBLIC -DO_STATIC_LIBRARY)
     set_target_properties(orcania_static PROPERTIES
             OUTPUT_NAME orcania)
+    if (MSVC)
+        set_target_properties(orcania_static PROPERTIES
+                OUTPUT_NAME orcania-static)
+    else ()
+        set_target_properties(orcania_static PROPERTIES
+            COMPILE_OPTIONS "-Wextra;-Wconversion")
+    endif ()
+    set(orcania_lib orcania_static)
 endif ()
 
 # shared library
 
-add_library(orcania SHARED ${LIB_SRC})
-if (NOT MSVC)
+if (BUILD_SHARED)
+    add_library(orcania SHARED ${LIB_SRC})
     set_target_properties(orcania PROPERTIES
-            COMPILE_OPTIONS "-Wextra;-Wconversion"
             PUBLIC_HEADER "${INC_DIR}/orcania.h;${PROJECT_BINARY_DIR}/orcania-cfg.h"
             VERSION "${LIBRARY_VERSION}"
-            SOVERSION "${LIBRARY_SOVERSION}")
-endif()
-if (WIN32)
-    set_target_properties(orcania PROPERTIES SUFFIX "-${LIBRARY_VERSION_MAJOR}.dll")
+            SOVERSION "${LIBRARY_SOVERSION}"
+            WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+    if (NOT MSVC)
+        set_target_properties(orcania PROPERTIES
+            COMPILE_OPTIONS "-Wextra;-Wconversion")
+    endif ()
+    if (WIN32)
+        set_target_properties(orcania PROPERTIES
+                    SUFFIX "-${LIBRARY_VERSION_MAJOR}.dll")
+    endif ()
+    target_link_libraries(orcania ${LIBS})
+    set(orcania_lib orcania)
 endif ()
-target_link_libraries(orcania ${LIBS})
 
 # documentation
 
@@ -164,9 +185,12 @@ option(BUILD_BASE64URL "Build base64url application." ON)
 
 if (BUILD_BASE64URL)
     add_executable(base64url ${BASE64URL_DIR}/base64url.c ${INC_DIR}/orcania.h ${PROJECT_BINARY_DIR}/orcania-cfg.h)
-    set_target_properties(base64url PROPERTIES SKIP_BUILD_RPATH TRUE COMPILE_OPTIONS "-Wextra;-Wconversion")
-    add_dependencies(base64url orcania)
-    target_link_libraries(base64url orcania ${LIBS})
+    set_target_properties(base64url PROPERTIES SKIP_BUILD_RPATH TRUE)
+    if (NOT MSVC)
+        set_target_properties(base64url COMPILE_OPTIONS "-Wextra;-Wconversion")
+    endif ()
+    add_dependencies(base64url ${orcania_lib})
+    target_link_libraries(base64url ${orcania_lib} ${LIBS})
     install(TARGETS base64url RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     install(FILES ${BASE64URL_DIR}/base64url.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1 COMPONENT runtime)
 endif ()
@@ -244,9 +268,12 @@ configure_file(liborcania.pc.in liborcania.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/liborcania.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-set(TARGETS orcania)
+set(TARGETS )
+if (BUILD_SHARED)
+    list(APPEND TARGETS orcania)
+endif ()
 if (BUILD_STATIC)
-    set(TARGETS ${TARGETS} orcania_static)
+    list(APPEND TARGETS orcania_static)
 endif ()
 
 if (INSTALL_HEADER)
@@ -320,6 +347,7 @@ add_custom_target(dist_o
         COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 
 message(STATUS "Force inline implementation of strstr: ${WITH_STRSTR}")
+message(STATUS "Build shared library:                  ${BUILD_SHARED}")
 message(STATUS "Build static library:                  ${BUILD_STATIC}")
 message(STATUS "Build testing tree:                    ${BUILD_ORCANIA_TESTING}")
 message(STATUS "Install the header files:              ${INSTALL_HEADER}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,25 +296,27 @@ else ()
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()
 
-set(ORCANIA_INSTALL_CMAKEDIR_DEFAULT "${CMAKE_INSTALL_LIBDIR}/cmake/Orcania")
-if (WIN32 AND NOT MINGW)
-    set(ORCANIA_INSTALL_CMAKEDIR_DEFAULT "cmake")
+if (INSTALL_HEADER)
+    set(ORCANIA_INSTALL_CMAKEDIR_DEFAULT "${CMAKE_INSTALL_LIBDIR}/cmake/Orcania")
+    if (WIN32 AND NOT MINGW)
+        set(ORCANIA_INSTALL_CMAKEDIR_DEFAULT "cmake")
+    endif ()
+    set(ORCANIA_INSTALL_CMAKEDIR ${ORCANIA_INSTALL_CMAKEDIR_DEFAULT} CACHE STRING "Location where to install the cmake config files")
+
+    install(EXPORT OrcaniaExports DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}"
+            NAMESPACE "Orcania::"
+            FILE "OrcaniaTargets.cmake")
+
+    configure_package_config_file(cmake-modules/OrcaniaConfig.cmake.in OrcaniaConfig.cmake
+            INSTALL_DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}")
+    write_basic_package_version_file(OrcaniaConfigVersion.cmake
+            COMPATIBILITY AnyNewerVersion)
+
+    install(FILES
+                "${PROJECT_BINARY_DIR}/OrcaniaConfig.cmake"
+                "${PROJECT_BINARY_DIR}/OrcaniaConfigVersion.cmake"
+            DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}")
 endif ()
-set(ORCANIA_INSTALL_CMAKEDIR ${ORCANIA_INSTALL_CMAKEDIR_DEFAULT} CACHE STRING "Location where to install the cmake config files")
-
-install(EXPORT OrcaniaExports DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}"
-        NAMESPACE "Orcania::"
-        FILE "OrcaniaTargets.cmake")
-
-configure_package_config_file(cmake-modules/OrcaniaConfig.cmake.in OrcaniaConfig.cmake
-        INSTALL_DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}")
-write_basic_package_version_file(OrcaniaConfigVersion.cmake
-        COMPATIBILITY AnyNewerVersion)
-
-install(FILES
-            "${PROJECT_BINARY_DIR}/OrcaniaConfig.cmake"
-            "${PROJECT_BINARY_DIR}/OrcaniaConfigVersion.cmake"
-        DESTINATION "${ORCANIA_INSTALL_CMAKEDIR}")
 
 # uninstall target
 

--- a/cmake-modules/FindCheck.cmake
+++ b/cmake-modules/FindCheck.cmake
@@ -68,6 +68,12 @@ find_package_handle_standard_args(Check
 if (CHECK_FOUND)
     set(CHECK_LIBRARIES ${CHECK_LIBRARY})
     set(CHECK_INCLUDE_DIRS ${CHECK_INCLUDE_DIR})
+    if (NOT TARGET Check::Check)
+        add_library(Check::Check IMPORTED UNKNOWN)
+        set_target_properties(Check::Check PROPERTIES
+                IMPORTED_LOCATION "${CHECK_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${CHECK_INCLUDE_DIR}")
+    endif ()
 endif ()
 
 mark_as_advanced(CHECK_INCLUDE_DIR CHECK_LIBRARY)

--- a/cmake-modules/FindSubunit.cmake
+++ b/cmake-modules/FindSubunit.cmake
@@ -54,6 +54,12 @@ find_package_handle_standard_args(Subunit
 if (SUBUNIT_FOUND)
     set(SUBUNIT_LIBRARIES ${SUBUNIT_LIBRARY})
     set(SUBUNIT_INCLUDE_DIRS ${SUBUNIT_INCLUDE_DIR})
+    if (NOT TARGET Subunit::Subunit)
+        add_library(Subunit::Subunit IMPORTED UNKNOWN)
+        set_target_properties(Subunit::Subunit PROPERTIES
+                IMPORTED_LOCATION "${SUBUNIT_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${SUBUNIT_INCLUDE_DIR}")
+    endif ()
 endif ()
 
 mark_as_advanced(SUBUNIT_INCLUDE_DIR SUBUNIT_LIBRARY)

--- a/cmake-modules/OrcaniaConfig.cmake.in
+++ b/cmake-modules/OrcaniaConfig.cmake.in
@@ -1,0 +1,16 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/OrcaniaTargets.cmake")
+
+if(TARGET Orcania::Orcania-static)
+    set(ORCANIA_INCLUDE_DIRS $<TARGET_PROPERTY:Orcania::Orcania-static,INTERFACE_INCLUDE_DIRECTORIES>)
+    set(ORCANIA_LIBRARIES Orcania::Orcania-static)
+endif()
+
+if(TARGET Orcania::Orcania)
+    set(ORCANIA_INCLUDE_DIRS $<TARGET_PROPERTY:Orcania::Orcania,INTERFACE_INCLUDE_DIRECTORIES>)
+    set(ORCANIA_LIBRARIES Orcania::Orcania)
+endif()
+
+set(ORCANIA_VERSION_STRING "@PROJECT_VERSION@")
+set(Orcania_FOUND TRUE)

--- a/src/orcania.c
+++ b/src/orcania.c
@@ -38,6 +38,11 @@
 #define strcasecmp _stricmp
 #endif
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 /**
  * 
  * Orcania library

--- a/tools/base64url/base64url.c
+++ b/tools/base64url/base64url.c
@@ -40,6 +40,8 @@ typedef SSIZE_T ssize_t;
 
 #define DEFAULT_WRAP 76
 
+#define SIZE 100
+
 static void print_output(const unsigned char * output, size_t output_len, unsigned long int wrap, short int ignore) {
   size_t i;
   for (i=0; i<output_len; i++) {
@@ -105,12 +107,11 @@ static unsigned char * get_file_content(const char * file_path, size_t * length)
 }
 
 static unsigned char * get_stdin_content(size_t * length) {
-  int size = 100;
-  unsigned char * out = NULL, buffer[size];
+  unsigned char * out = NULL, buffer[SIZE];
   ssize_t read_length;
 
   *length = 0;
-  while ((read_length = read(0, buffer, (size_t)size)) > 0) {
+  while ((read_length = read(0, buffer, SIZE)) > 0) {
     out = o_realloc(out, (*length)+(size_t)read_length+1);
     memcpy(out+(*length), buffer, (size_t)read_length);
     (*length) += (size_t)read_length;

--- a/tools/base64url/base64url.c
+++ b/tools/base64url/base64url.c
@@ -19,12 +19,19 @@
  * 
  */
 
-#include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <getopt.h>
 #include <ctype.h>
 #include <orcania.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+#include <unistd.h>
+#endif
 
 #define _BASE64URL_VERSION "0.9"
 


### PR DESCRIPTION
Hello, I'm in the process with creating a conan recipe for ulfius, which has orcania as one of its dependencies.
By applying these patches, I am able to build this library with Visual Studio 2019.

- `ssize_t` is not available with Visual Studio. So I applied [this suggestion](https://www.scivision.dev/ssize_t-visual-studio-posix/)
- conan recipes usually have an option to package shared/static libraries. To avoid having to build the shared library, when only wanting to package the shared library, this pr adds a `BUILD_SHARED` cmake option.
  I have also fixed building a dll by setting the [`WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html) property.
  I was careful to not change the default behavior of the cmake script.
- `base64url.exe` also failed to build because the size of an array must be a constant.

Fixes #29 
Used in https://github.com/conan-io/conan-center-index/pull/13589